### PR TITLE
Change game container to a 16:9 aspect ratio

### DIFF
--- a/Gamma/4.2/index.html
+++ b/Gamma/4.2/index.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <div class="webgl-content">
-      <div id="gameContainer" style="width: 960px; height: 600px"></div>
+      <div id="gameContainer" style="width: 960px; height: 540px"></div>
       <div class="footer">
         <div class="webgl-logo"></div>
         <div class="fullscreen" onclick="gameInstance.SetFullscreen(1)"></div>


### PR DESCRIPTION
Game seem to be designed for a 16:9, but the Unity game container is 16:10.
Some elements (e.g. sliders and the numbers next to them) get shifted and look off in the game container at 16:10, but look correct when in full screen at 16:9